### PR TITLE
Add @types/cls-hooked-compatible type declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         run: npm ci
       - name: Compile
         run: npm run compile
+      - name: Type declaration compatibility
+        run: npm run test:types
       - name: Verify CommonJS drop-in interface
         run: |
           node -e "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,24 @@ Sequelize v6 `useCLS` patterns (byte-identical observable behavior).
    couldn't propagate implicitly either and middleware already binds
    req/res.
 
+### TypeScript declarations (drop-in for @types/cls-hooked)
+
+The package ships hand-authored type declarations (`types/index.d.ts`) shaped
+to match `@types/cls-hooked@4.3.x`, so TypeScript consumers can drop the
+`@types` package and keep compiling with zero code changes — including the
+generic `Namespace<N>` interface, namespace-qualified type access through a
+default import (`cls.Namespace`), and partial mock casts in tests. The
+declarations, not the (stricter) implementation types, are the public
+contract; compatibility is enforced by type-level tests (`npm run
+test:types`) compiled under both `bundler` and `NodeNext` module resolution.
+
+New v5 API is declared additively: `getNamespaces()` and `ERROR_SYMBOL`.
+
+One deliberate divergence is retained from `@types/cls-hooked`:
+`getNamespace()` is declared to return `Namespace | undefined`, but at
+runtime a _destroyed_ namespace returns `null` (falsy either way) — matching
+what existing code was written against.
+
 ### bindEmitter internals (emitter-listener replaced)
 
 The abandoned, untested `emitter-listener` package (and its transitive
@@ -80,7 +98,8 @@ safely bind the same emitter. Minor observable differences:
   (AsyncContextFrame-backed ALS).
 - Compiled output targets ES2022 (was ES5) — native classes and
   async/await instead of downleveled helper code.
-- Source ported to TypeScript; type declarations shipped.
+- Source ported to TypeScript; type declarations shipped (see "TypeScript
+  declarations" above — remove `@types/cls-hooked` when upgrading).
 - Package exposes the same CommonJS named exports as v4
   (`require('@farmersdog/cls-hooked').createNamespace` etc.) plus a default
   export for ESM/TS consumers.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ package behind `bindEmitter` was replaced by an in-repo, unit-tested module
 that binds listeners when they are added instead of patching `emit` (see the
 [CHANGELOG](./CHANGELOG.md#v500) for the few observable differences).
 
+v5 ships its own TypeScript declarations, shaped to be a drop-in replacement
+for `@types/cls-hooked` — remove that package from your devDependencies when
+upgrading; no code changes are needed.
+
 ## Usage
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmersdog/cls-hooked",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "description": "Fork of the cls-hooked package, maintained by The Farmer's Dog Engineering",
   "keywords": [
     "context",
@@ -14,14 +14,16 @@
     "url": "git+https://github.com/farmersdog/cls-hooked.git"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "types/"
   ],
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "tap --disable-coverage test/tap/*.tap.ts",
+    "test:types": "tsc -p test/types/tsconfig.bundler.json && tsc -p test/types/tsconfig.nodenext.json",
     "compile": "tsc -p tsconfig.build.json",
-    "prepack": "npm run compile",
+    "prepack": "rm -rf dist && npm run compile",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt .",

--- a/test/types/barrel-consumer.ts
+++ b/test/types/barrel-consumer.ts
@@ -1,0 +1,22 @@
+/**
+ * Patterns consuming the re-export barrel.
+ */
+import cls from "./barrel";
+import type { Namespace } from "./barrel";
+
+// Namespace-qualified type access through the re-exported default binding.
+export function getClsNamespace(): cls.Namespace | undefined {
+  return cls.getNamespace("session");
+}
+
+export type StringOrNamespace = string | cls.Namespace;
+
+export const viaNamedType: Namespace | undefined = cls.getNamespace("session");
+
+// Partial mock cast, then used where createNamespace's return type is
+// expected (jest's mockReturnValue).
+export const mock = {
+  set: (() => undefined) as cls.Namespace["set"],
+  run: (cb: () => unknown) => cb(),
+} as cls.Namespace;
+export const created: ReturnType<typeof cls.createNamespace> = mock;

--- a/test/types/barrel.ts
+++ b/test/types/barrel.ts
@@ -1,0 +1,12 @@
+/**
+ * A common consumption shape: a re-export barrel that imports the library
+ * once and re-exports it, with the rest of the codebase consuming the
+ * default export — including namespace-qualified type access
+ * (`cls.Namespace`) via barrel-consumer.ts.
+ */
+import hooked from "cls-hooked";
+import type { Namespace } from "cls-hooked";
+import type CLS from "cls-hooked";
+
+export type { Namespace, CLS };
+export default hooked;

--- a/test/types/conformance.ts
+++ b/test/types/conformance.ts
@@ -1,0 +1,28 @@
+/**
+ * The implementation must satisfy the declared surface (at the default
+ * generic instantiation), so the hand-authored declarations can't silently
+ * drift from the code.
+ */
+import type { Namespace } from "cls-hooked";
+import * as decl from "cls-hooked";
+import implDefault from "../../index";
+import * as impl from "../../index";
+
+export const createNamespace: (name: string) => Namespace = impl.createNamespace;
+// Deliberate divergence: runtime returns `null` for a destroyed namespace;
+// declared as undefined-only to match the @types/cls-hooked contract.
+export const getNamespace: (name: string) => Namespace | null | undefined = impl.getNamespace;
+export const destroyNamespace: typeof decl.destroyNamespace = impl.destroyNamespace;
+export const reset: typeof decl.reset = impl.reset;
+export const getNamespaces: () => Record<string, Namespace | null> = impl.getNamespaces;
+export const errorSymbol: typeof decl.ERROR_SYMBOL = impl.ERROR_SYMBOL;
+
+// The default export must carry the same surface.
+export const dflt: {
+  createNamespace: (name: string) => Namespace;
+  getNamespace: (name: string) => Namespace | null | undefined;
+  destroyNamespace: typeof decl.destroyNamespace;
+  reset: typeof decl.reset;
+  getNamespaces: () => Record<string, Namespace | null>;
+  ERROR_SYMBOL: string;
+} = implDefault;

--- a/test/types/consumer-patterns.ts
+++ b/test/types/consumer-patterns.ts
@@ -1,0 +1,59 @@
+/**
+ * Consumer patterns that must keep compiling — the idioms codebases written
+ * against @types/cls-hooked rely on. Compiled (never executed) by
+ * `npm run test:types` under both bundler and NodeNext module resolution.
+ */
+import cls from "cls-hooked";
+import {
+  createNamespace,
+  destroyNamespace,
+  ERROR_SYMBOL,
+  getNamespace,
+  getNamespaces,
+  reset,
+} from "cls-hooked";
+import type { Namespace } from "cls-hooked";
+
+// Qualified type access through the default import.
+export declare const qualified: cls.Namespace;
+
+// getNamespace annotated as `Namespace | undefined` (the @types contract).
+export const maybe: Namespace | undefined = cls.getNamespace("session");
+
+// Partial jest-style mock cast directly to Namespace.
+export const mockNamespace = {
+  set: ((..._args: unknown[]) => undefined) as Namespace["set"],
+  get: ((..._args: unknown[]) => undefined) as Namespace["get"],
+  runPromise: ((fn: () => Promise<unknown>) => fn()) as Namespace["runPromise"],
+  run: (cb: () => unknown) => cb(),
+} as Namespace;
+
+// `get` implementations may type the key as plain string.
+export const getByInferredKey: Namespace["get"] = (key) => {
+  const k: string = key;
+  return k;
+};
+export const getByExplicitString: Namespace["get"] = (key: string) => key;
+
+// Generic namespaces constrain keys and value types.
+export const typed = createNamespace<{ userId: number }>("typed");
+typed.set("userId", 1);
+// @ts-expect-error value type must match the namespace shape
+typed.set("userId", "nope");
+// @ts-expect-error unknown keys are rejected
+typed.get("unknown");
+
+// `active` is any — loose reads compile.
+export const activeIsAny: boolean = createNamespace("a").active;
+
+// Remaining named exports keep their v4 call shapes.
+export function lifecycle(): void {
+  const ns = getNamespace("session");
+  ns?.run(() => undefined);
+  destroyNamespace("session");
+  reset();
+}
+
+// New v5 API.
+export const registry: Record<string, Namespace | null> = getNamespaces();
+export const errKey: string = ERROR_SYMBOL;

--- a/test/types/tsconfig.bundler.json
+++ b/test/types/tsconfig.bundler.json
@@ -1,0 +1,16 @@
+{
+  // Mirrors a bundler-resolved consumer (module: es2022, moduleResolution:
+  // bundler, esModuleInterop).
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": { "cls-hooked": ["../../types/index.d.ts"] }
+  },
+  "include": ["./*.ts"]
+}

--- a/test/types/tsconfig.nodenext.json
+++ b/test/types/tsconfig.nodenext.json
@@ -1,0 +1,15 @@
+{
+  // Mirrors a NodeNext-resolved CommonJS consumer.
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": { "cls-hooked": ["../../types/index.d.ts"] }
+  },
+  "include": ["./*.ts"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  // Declarations are not generated: the hand-authored types/index.d.ts is
+  // the public type surface (shaped for @types/cls-hooked compatibility).
+  "compilerOptions": { "declaration": false },
   "include": ["index.ts", "cls-async-storage.ts", "wrap-emitter.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    // Resolve the package self-import in test/types to the hand-authored
+    // public declarations (the shipped `types` entry).
+    "paths": { "cls-hooked": ["./types/index.d.ts"] }
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,47 @@
+/**
+ * Hand-authored public type declarations.
+ *
+ * The shape deliberately mirrors `@types/cls-hooked@4.3.x` (DefinitelyTyped,
+ * MIT licensed) so that v4 consumers switching to v5 keep compiling with zero
+ * code changes — the declarations, not the (stricter) implementation types,
+ * are the public contract. New v5 API is declared additively at the bottom.
+ * Type-level compatibility is enforced by `npm run test:types`.
+ */
+
+import { EventEmitter } from "node:events";
+
+export interface Namespace<N = Record<string, any>> {
+  active: any;
+
+  set<K extends keyof N = keyof N>(key: K, value: N[K]): N[K];
+  get<K extends keyof N = keyof N>(key: K): N[K];
+  run(fn: (...args: any[]) => void): void;
+  runAndReturn<T>(fn: (...args: any[]) => T): T;
+  runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T>;
+  bind<F extends Function>(fn: F, context?: any): F;
+  bindEmitter(emitter: EventEmitter): void;
+  createContext(): any;
+  enter(context: any): void;
+  exit(context: any): void;
+}
+
+export function createNamespace<N = Record<string, any>>(name: string): Namespace<N>;
+/**
+ * Declared as `Namespace | undefined` to match the `@types/cls-hooked`
+ * contract existing code was written against; at runtime a *destroyed*
+ * namespace returns `null` (falsy either way).
+ */
+export function getNamespace<N = Record<string, any>>(name: string): Namespace<N> | undefined;
+export function destroyNamespace(name: string): void;
+export function reset(): void;
+
+// --- New in v5 (not present in @types/cls-hooked) ---
+
+/**
+ * The registry of all namespaces, keyed by name (`null` marks a destroyed
+ * namespace). Replaces v4's `process.namespaces`.
+ */
+export function getNamespaces(): Record<string, Namespace | null>;
+
+/** Key under which run/bind attach the failing context to a thrown error. */
+export const ERROR_SYMBOL: string;


### PR DESCRIPTION
## Context

The v5 alpha shipped tsc-generated declarations from the TypeScript source. For consumers migrating from v4 + `@types/cls-hooked`, that made the *types* a breaking change even though the runtime is drop-in: the public interface was renamed (`Namespace` → `CLSNamespace`), `createNamespace`/`getNamespace` were typed as returning the concrete class (whose TS-private fields make partial mocks and `mockReturnValue` unsatisfiable in tests), namespace-qualified type access through a default import (`cls.Namespace`) stopped compiling, and signatures drifted (`get`/`set` keys, `active`, `getNamespace` nullability).

## Solution

Treat the declarations — not the implementation types — as the public contract, the same way the v4 runtime was treated as the contract for the rewrite:

- Hand-authored `types/index.d.ts` shaped to match `@types/cls-hooked@4.3.x`, with new v5 API (`getNamespaces()`, `ERROR_SYMBOL`) declared additively.
- Generated declarations are no longer emitted or shipped; `prepack` cleans `dist/` so stale ones can't leak into the tarball.
- One deliberate divergence retained from `@types`: `getNamespace()` is declared `Namespace | undefined` while a destroyed namespace returns `null` at runtime (falsy either way) — matching what existing code was written against.

Bumps version to `5.0.0-alpha.2`.

## Testing

New type-level test suite (`npm run test:types`, wired into the CI compile job) compiles consumer idioms — type-only `Namespace` imports, `cls.Namespace` qualified access directly and through a re-export barrel, partial jest-style mock casts, `mockReturnValue`-shaped assignments, generic `Namespace<N>` key/value constraints — under both `bundler` and `NodeNext` module resolution. An implementation-conformance file assigns the real exports to the declared surface so the hand-written declarations can't silently drift from the code. Existing 558 tap tests unchanged and passing.

## What could go wrong?

The declarations are looser than the implementation (`any`-heavy contexts, by design), so new-code consumers get weaker type safety than the generated types offered — accepted trade-off; the README already steers new projects to `AsyncLocalStorage` directly. If a consumer pattern isn't covered by the type tests, it could still regress; the suite is the place to add such cases as they're found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)