### PR TITLE
Fix exit() wiping the ALS frame on re-entrant bind and raw enter/exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ safely bind the same emitter. Minor observable differences:
 - Test suite consolidated on `tap` (mocha/chai removed), coverage restored
   to parity with v4 and extended with differential-parity regression tests
   (`test/tap/als-parity.tap.ts`).
+- (fixed during the alpha series) `exit()` restores the
+  `AsyncLocalStorage` frame recorded at the matching `enter()` instead of
+  the sync-stack value, so a `bind()` invoked synchronously inside the very
+  context it captured (the context-logger idiom), and raw `enter()`/`exit()`
+  pairs in async continuations, no longer wipe the chain's context
+  (`test/tap/reentrant-bind-exit.tap.ts`).
 
 ### Tooling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,12 +106,6 @@ safely bind the same emitter. Minor observable differences:
 - Test suite consolidated on `tap` (mocha/chai removed), coverage restored
   to parity with v4 and extended with differential-parity regression tests
   (`test/tap/als-parity.tap.ts`).
-- (fixed during the alpha series) `exit()` restores the
-  `AsyncLocalStorage` frame recorded at the matching `enter()` instead of
-  the sync-stack value, so a `bind()` invoked synchronously inside the very
-  context it captured (the context-logger idiom), and raw `enter()`/`exit()`
-  pairs in async continuations, no longer wipe the chain's context
-  (`test/tap/reentrant-bind-exit.tap.ts`).
 
 ### Tooling
 

--- a/cls-async-storage.ts
+++ b/cls-async-storage.ts
@@ -53,12 +53,24 @@ class Namespace implements CLSNamespace {
   name: string;
   private _active: Context | null;
   private _set: Array<Context | null>;
+  // Parallel to _set: the AsyncLocalStorage store observed at each enter(),
+  // restored by the matching exit(). exit() must NOT restore from the sync
+  // stack (_active): when enter/exit runs inside an async continuation,
+  // _active is long since null even though the ALS frame still carries the
+  // chain's context — restoring _active would stamp `undefined` into the
+  // frame and annihilate the context for the rest of the chain. This bites
+  // hard because AsyncLocalStorage.run() short-circuits (no frame
+  // save/restore) when the requested store is already current, which is
+  // exactly what happens when bind() is invoked synchronously in the very
+  // context it captured (the context-logger idiom).
+  private _enterStores: Array<Context | undefined>;
   private _storage: AsyncLocalStorage<Context | undefined>;
 
   constructor(name: string) {
     this.name = name;
     this._active = null;
     this._set = [];
+    this._enterStores = [];
     this._storage = new AsyncLocalStorage<Context | undefined>();
   }
 
@@ -239,6 +251,7 @@ class Namespace implements CLSNamespace {
     // Push the sync-stack value (not the getter): enter() may run inside
     // _storage.run() where the getter already resolves to the new context.
     this._set.push(this._active);
+    this._enterStores.push(this._storage.getStore());
     this._active = context;
     this._storage.enterWith(context);
   }
@@ -259,7 +272,7 @@ class Namespace implements CLSNamespace {
 
       const popped = this._set.pop();
       this._active = popped === undefined ? null : popped;
-      this._storage.enterWith(this._active ?? undefined);
+      this._storage.enterWith(this._enterStores.pop());
       return;
     }
 
@@ -280,6 +293,7 @@ class Namespace implements CLSNamespace {
       // Exiting a context that is not the current one: remove it from the
       // stack without touching the current frame (matches cls-hooked 4.x).
       this._set.splice(index, 1);
+      this._enterStores.splice(index, 1);
     }
   }
 

--- a/cls-async-storage.ts
+++ b/cls-async-storage.ts
@@ -53,16 +53,10 @@ class Namespace implements CLSNamespace {
   name: string;
   private _active: Context | null;
   private _set: Array<Context | null>;
-  // Parallel to _set: the AsyncLocalStorage store observed at each enter(),
-  // restored by the matching exit(). exit() must NOT restore from the sync
-  // stack (_active): when enter/exit runs inside an async continuation,
-  // _active is long since null even though the ALS frame still carries the
-  // chain's context — restoring _active would stamp `undefined` into the
-  // frame and annihilate the context for the rest of the chain. This bites
-  // hard because AsyncLocalStorage.run() short-circuits (no frame
-  // save/restore) when the requested store is already current, which is
-  // exactly what happens when bind() is invoked synchronously in the very
-  // context it captured (the context-logger idiom).
+  // Parallel to _set: the ALS store observed at each enter(), restored by
+  // the matching exit(). Restoring _active instead would wipe the frame for
+  // enter/exit pairs inside async continuations, where _active is null but
+  // the frame still carries the chain's context.
   private _enterStores: Array<Context | undefined>;
   private _storage: AsyncLocalStorage<Context | undefined>;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmersdog/cls-hooked",
-  "version": "5.0.0-alpha.2",
+  "version": "5.0.0-alpha.3",
   "description": "Fork of the cls-hooked package, maintained by The Farmer's Dog Engineering",
   "keywords": [
     "context",

--- a/test/tap/reentrant-bind-exit.tap.ts
+++ b/test/tap/reentrant-bind-exit.tap.ts
@@ -1,9 +1,5 @@
 "use strict";
 
-// exit() must restore the ALS store observed at the matching enter(), not
-// the sync-stack value. ALS.run() skips frame save/restore when the store is
-// already current, so a bind() invoked synchronously in the context it
-// captured depends entirely on exit() restoring the right value.
 import * as tap from "tap";
 import cls from "../../index";
 

--- a/test/tap/reentrant-bind-exit.tap.ts
+++ b/test/tap/reentrant-bind-exit.tap.ts
@@ -9,8 +9,6 @@ test("bind() invoked synchronously inside its own context keeps the chain's cont
   const ns = cls.createNamespace("reentrant-bind");
   t.teardown(() => cls.destroyNamespace("reentrant-bind"));
 
-  // The context-logger idiom: bind to the currently-active context and call
-  // the bound function immediately.
   const readViaBind = (): unknown => {
     const bound = ns.bind(() => ns.get("k"));
     return bound();

--- a/test/tap/reentrant-bind-exit.tap.ts
+++ b/test/tap/reentrant-bind-exit.tap.ts
@@ -40,8 +40,6 @@ test("bind(fn, ns.active) invoked synchronously keeps the chain's context", asyn
     ns.set("k", 1);
     await new Promise((resolve) => setTimeout(resolve, 5));
 
-    // Explicit-context flavor of the same idiom (what bindEmitter's wrap
-    // does when an emitter fires inside the context its listener captured).
     const bound = ns.bind(() => ns.get("k"), ns.active!);
     t.equal(bound(), 1, "explicitly re-bound function sees the context");
 

--- a/test/tap/reentrant-bind-exit.tap.ts
+++ b/test/tap/reentrant-bind-exit.tap.ts
@@ -1,14 +1,9 @@
 "use strict";
 
-// Regression tests for exit() restoring the AsyncLocalStorage frame from the
-// sync enter/exit stack instead of the store observed at the matching
-// enter(). AsyncLocalStorage.run() short-circuits (no frame save/restore)
-// when the requested store is already current, so a bind() invoked
-// synchronously in the very context it captured relied entirely on exit()
-// putting the right value back — restoring the sync-stack value (null by
-// then, inside an async continuation) stamped `undefined` into the frame and
-// annihilated the chain's context. cls-hooked 4.x never touched async
-// propagation from exit(), so these patterns all worked there.
+// exit() must restore the ALS store observed at the matching enter(), not
+// the sync-stack value. ALS.run() skips frame save/restore when the store is
+// already current, so a bind() invoked synchronously in the context it
+// captured depends entirely on exit() restoring the right value.
 import * as tap from "tap";
 import cls from "../../index";
 

--- a/test/tap/reentrant-bind-exit.tap.ts
+++ b/test/tap/reentrant-bind-exit.tap.ts
@@ -1,0 +1,111 @@
+"use strict";
+
+// Regression tests for exit() restoring the AsyncLocalStorage frame from the
+// sync enter/exit stack instead of the store observed at the matching
+// enter(). AsyncLocalStorage.run() short-circuits (no frame save/restore)
+// when the requested store is already current, so a bind() invoked
+// synchronously in the very context it captured relied entirely on exit()
+// putting the right value back — restoring the sync-stack value (null by
+// then, inside an async continuation) stamped `undefined` into the frame and
+// annihilated the chain's context. cls-hooked 4.x never touched async
+// propagation from exit(), so these patterns all worked there.
+import * as tap from "tap";
+import cls from "../../index";
+
+const test = tap.test;
+
+test("bind() invoked synchronously inside its own context keeps the chain's context", async (t) => {
+  const ns = cls.createNamespace("reentrant-bind");
+  t.teardown(() => cls.destroyNamespace("reentrant-bind"));
+
+  // The context-logger idiom: bind to the currently-active context and call
+  // the bound function immediately.
+  const readViaBind = (): unknown => {
+    const bound = ns.bind(() => ns.get("k"));
+    return bound();
+  };
+
+  const handler = ns.bind(async () => {
+    ns.set("k", "before");
+    t.equal(readViaBind(), "before", "re-entrant bind sees the context (sync)");
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    t.equal(readViaBind(), "before", "re-entrant bind sees the context (after await)");
+    ns.set("k2", "after");
+    t.equal(ns.get("k"), "before", "context survives the re-entrant bind");
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    t.equal(ns.get("k2"), "after", "context still propagates after further awaits");
+  });
+
+  await handler();
+});
+
+test("bind(fn, ns.active) invoked synchronously keeps the chain's context", async (t) => {
+  const ns = cls.createNamespace("reentrant-bind-explicit");
+  t.teardown(() => cls.destroyNamespace("reentrant-bind-explicit"));
+
+  const handler = ns.bind(async () => {
+    ns.set("k", 1);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    // Explicit-context flavor of the same idiom (what bindEmitter's wrap
+    // does when an emitter fires inside the context its listener captured).
+    const bound = ns.bind(() => ns.get("k"), ns.active!);
+    t.equal(bound(), 1, "explicitly re-bound function sees the context");
+
+    ns.set("k", 2);
+    t.equal(ns.get("k"), 2, "context survives the re-entrant bind");
+  });
+
+  await handler();
+});
+
+test("raw enter()/exit() pair inside an async continuation keeps the chain's context", async (t) => {
+  const ns = cls.createNamespace("reentrant-enter-exit");
+  t.teardown(() => cls.destroyNamespace("reentrant-enter-exit"));
+
+  const handler = ns.bind(async () => {
+    ns.set("k", "outer");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const inner = ns.createContext();
+    ns.enter(inner);
+    ns.set("k", "inner");
+    t.equal(ns.get("k"), "inner", "inner context is active between enter/exit");
+    ns.exit(inner);
+
+    t.equal(ns.get("k"), "outer", "outer context restored after exit()");
+    ns.set("k2", "still here");
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    t.equal(ns.get("k2"), "still here", "outer context still propagates after awaits");
+  });
+
+  await handler();
+});
+
+test("out-of-order exit still restores the pre-nesting store", (t) => {
+  const ns = cls.createNamespace("reentrant-out-of-order");
+  t.teardown(() => cls.destroyNamespace("reentrant-out-of-order"));
+
+  ns.run(() => {
+    ns.set("k", "base");
+
+    const a = ns.createContext();
+    const b = ns.createContext();
+    ns.enter(a);
+    ns.enter(b);
+    ns.exit(a); // out of order: a is not on top
+    t.equal(ns.get("k"), "base", "b (prototype-inheriting) still resolves values");
+    ns.exit(b);
+
+    t.equal(ns.get("k"), "base", "run() context restored after unwinding");
+    ns.set("k2", "ok");
+    t.equal(ns.get("k2"), "ok", "run() context is writable after unwinding");
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Context

Trialing `5.0.0-alpha.2` against a large consumer's medium test suite surfaced two failure shapes: `No context available` thrown from `ns.set()` *inside* a bound async handler, and CLS-carried values (Sequelize transactions, owner scoping) silently going missing after certain calls. Both reduce to one minimal repro that works on v4 and throws on the v5 alphas:

```js
const handler = ns.bind(async () => {
  ns.set('k', 'hello');
  await sleep(5);
  ns.bind(() => ns.get('k'))();  // the context-logger idiom: bind + invoke synchronously
  ns.set('k2', 'world');         // v4: fine — v5 alphas: "No context available"
});
```

## Root cause

`exit()` restored the `AsyncLocalStorage` frame from the sync enter/exit stack (`_active`), which is long since `null` inside an async continuation. That's fatal in combination with a Node ALS detail: `AsyncLocalStorage.run()` **short-circuits with no frame save/restore when the requested store is already current** — exactly the case when `bind()` is invoked synchronously in the very context it captured. With no `run()` restore to undo it, `exit()`'s `enterWith(undefined)` permanently stamps the frame, killing the chain's context for everything downstream. Raw `enter()`/`exit()` pairs inside async continuations hit the same path. cls-hooked 4.x never touched async propagation from `exit()`, so both patterns worked there.

## Solution

`enter()` records the current store in a stack parallel to `_set`; `exit()` restores that recorded value instead of `_active` (spliced in lockstep on out-of-order exits). Behavior changes #1/#2 (no `runPromise` context bleed) are preserved — the no-bleed property comes from ALS frame capture, not from `exit()`'s frame write.

## Testing

New `test/tap/reentrant-bind-exit.tap.ts` covers: re-entrant `bind()` (implicit and explicit context) invoked synchronously after an await, raw `enter()`/`exit()` inside an async continuation, and out-of-order exits restoring the pre-nesting store. Each case verified to fail on the unfixed implementation and pass with the fix, on Node 22 and 24. Full suite: 570/570.

## What could go wrong?

Out-of-order enter/exit interleavings across concurrent chains sharing one namespace can still restore a sibling chain's recorded store — the same imperfection v4's single sync stack had, kept deliberately for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)